### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/src/utils/renderer.ts
+++ b/src/utils/renderer.ts
@@ -9,6 +9,7 @@ import hljs from 'highlight.js'
 import { marked } from 'marked'
 import mermaid from 'mermaid'
 import readingTime from 'reading-time'
+import { URL } from 'url'
 
 import { getStyleString } from '.'
 import markedAlert from './MDAlert'
@@ -279,8 +280,14 @@ export function initRenderer(opts: IOpts) {
 
     link({ href, title, text, tokens }: Tokens.Link): string {
       const parsedText = this.parser.parseInline(tokens)
-      if (href.startsWith(`https://mp.weixin.qq.com`)) {
-        return `<a href="${href}" title="${title || text}" ${styles(`wx_link`)}>${parsedText}</a>`
+      const allowedHosts = ['mp.weixin.qq.com']
+      try {
+        const url = new URL(href)
+        if (allowedHosts.includes(url.host)) {
+          return `<a href="${href}" title="${title || text}" ${styles(`wx_link`)}>${parsedText}</a>`
+        }
+      } catch (e) {
+        console.error('Invalid URL:', href)
       }
       if (href === text) {
         return parsedText


### PR DESCRIPTION
Potential fix for [https://github.com/CrazyMrYan/md-tauri/security/code-scanning/5](https://github.com/CrazyMrYan/md-tauri/security/code-scanning/5)

To fix the problem, we need to parse the URL and check its host value against a whitelist of allowed hosts. This ensures that the URL is not maliciously crafted to bypass the security check.

1. Parse the URL using a URL parsing library.
2. Extract the host from the parsed URL.
3. Check if the host is in a predefined list of allowed hosts.
4. If the host is allowed, proceed with the existing functionality; otherwise, handle the case appropriately (e.g., reject the URL or log an error).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
